### PR TITLE
Add badge for go static check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Haaukins-Kubernetes-bachelor-project
 
+[![go-static-check](https://github.com/Mai-Sigurd/Haaukins-Kubernetes-bachelor-project/actions/workflows/go-static-check.yml/badge.svg)](https://github.com/Mai-Sigurd/Haaukins-Kubernetes-bachelor-project/actions/workflows/go-static-check.yml)
+
 # Requirements
 Go-Swagger
   https://goswagger.io/install.html


### PR DESCRIPTION
Details on how to find it inside actions:
https://dev.to/azure/github-how-to-display-the-status-badge-for-a-github-action-5449