### PR TITLE
egress network policy did not work because it was trying to select po…

### DIFF
--- a/kali/kali.go
+++ b/kali/kali.go
@@ -19,6 +19,7 @@ func StartKaliImage(clientSet kubernetes.Clientset, namespace string) {
 	utils.InfoLogger.Println("Starting Kali")
 	podLabels := make(map[string]string)
 	podLabels[utils.KaliPodLabelKey] = utils.KaliPodLabelValue
+	podLabels[utils.NetworkPolicyLabelKey] = utils.NetworkPolicyLabelValue
 	ports := []int32{kaliRDPPort}
 	deployments.CreateDeployment(clientSet, namespace, "kali", kaliImageName, ports, podLabels)
 	services.CreateService(clientSet, namespace, "kali", ports)

--- a/netpol/netpol.go
+++ b/netpol/netpol.go
@@ -16,8 +16,7 @@ func CreateEgressPolicy(clientSet kubernetes.Clientset, namespace string) {
 	policyTypes := []networking.PolicyType{"Egress"}
 	egress := buildEgressRules()
 	matchLabels := make(map[string]string)
-	matchLabels[utils.KaliPodLabelKey] = utils.KaliPodLabelValue
-	matchLabels[utils.WireguardPodLabelKey] = utils.WireguardPodLabelValue
+	matchLabels[utils.NetworkPolicyLabelKey] = utils.NetworkPolicyLabelValue
 	createNetworkPolicy(clientSet, policyName, namespace, policyTypes, egress, nil, matchLabels)
 }
 

--- a/utils/const.go
+++ b/utils/const.go
@@ -13,4 +13,6 @@ const (
 	ChallengePodLabelValue  = "challenge"
 	KubernetesDNSLabelKey   = "k8s-app"
 	KubernetesDNSLabelValue = "kube-dns"
+	NetworkPolicyLabelKey   = "network"
+	NetworkPolicyLabelValue = "restricted"
 )

--- a/wireguard/wireguard.go
+++ b/wireguard/wireguard.go
@@ -78,13 +78,15 @@ func configureWireGuardDeployment() *appsv1.Deployment {
 			Replicas: utils.Int32Ptr(1),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					utils.WireguardPodLabelKey: utils.WireguardPodLabelValue,
+					utils.WireguardPodLabelKey:  utils.WireguardPodLabelValue,
+					utils.NetworkPolicyLabelKey: utils.NetworkPolicyLabelValue,
 				},
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						utils.WireguardPodLabelKey: utils.WireguardPodLabelValue,
+						utils.WireguardPodLabelKey:  utils.WireguardPodLabelValue,
+						utils.NetworkPolicyLabelKey: utils.NetworkPolicyLabelValue,
 					},
 				},
 				Spec: apiv1.PodSpec{


### PR DESCRIPTION
…ds with both kali and wireguard labels. Now they share a common label which is selected - tested on live cluster