### PR TITLE
Guac API

### DIFF
--- a/src/connections/browser/guacToKali.go
+++ b/src/connections/browser/guacToKali.go
@@ -9,6 +9,10 @@ import (
 
 func SetupGuacAndKali(guac guacamole.Guacamole, clientSet kubernetes.Clientset, name string, password string) (string, error) {
 	ip, port, err := kali.StartKali(clientSet, name, "kali")
+	if err != nil {
+		utils.ErrLogger(err)
+		return "", err
+	}
 
 	err = guac.UpdateAuthToken()
 	if err != nil {

--- a/src/tests/utils_test.go
+++ b/src/tests/utils_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"k8s-project/challenge"
 	"k8s-project/connections/browser/kali"
-	"k8s-project/connections/wireguard"
+	"k8s-project/connections/vpn/wireguard"
 	"k8s-project/namespaces"
 	"k8s-project/utils"
 	"log"


### PR DESCRIPTION
Adds ability to interact with the Guacamole API to create a user in Guacamole, create a connection to their Kali Linux, assign that connection to their Guacamole user. Also adds Guacamole K8s secret, src readme, updates Kali POST and main, etc. 

- [x] Add guac admin secret generation to guac init script
- [x] Find a way to send guac info around
- [x] Get guac secret func
- [x] Get guac access token func
- [x] Get guac base address func
- [x] Create guac user func
- [x] Create connection func
- [x] Assign guac connection to guac user func
- [x] Update readme general + guac
- [x] Make Kali wait for pod + service to be ready
- [x] Update Kali POST
- [x] Update main to get guac info
- [x] Automatically update admin password to match admin password K8s secret
- [x] Test it all
- [x] Add logging
- [x] Handle errors