### PR TITLE
Test several users

### DIFF
--- a/src/tests/resourceSeveralUsers_test.go
+++ b/src/tests/resourceSeveralUsers_test.go
@@ -8,9 +8,6 @@ import (
 	"time"
 )
 
-//This works in the sense that the test terminates when errors are returned from k8s api (e.g. resources are sparse) but the actual
-//deletion of namespaces and resources goes on even after the test exits....
-//
 // Find out how many users there can be run on a minimal kubernetes requirements server setup (with an amount of challenges running) while we wait in between the starting of namespaces
 func TestMaximumLoad(t *testing.T) {
 	/// 50/50 kali wireguard


### PR DESCRIPTION
- [x] Add function for adding namespaces until an error is returned from K8s api
- [x] Add function for adding namespaces until an error is returned from K8s api, but using goroutines

The tests do what they're supposed to: simulate adding users untill the K8s api backs down. But essentially any error from the K8s api will make the test stop and more importantly, the "comedown" time after hitting max resources is VERY long and not really measurable, as the node will have to stabilize and then start deleting resources etc. in it whatever tempo it can handle.

