### PR TITLE
Fix Guacamole

### DIFF
--- a/install-guacamole/README.md
+++ b/install-guacamole/README.md
@@ -7,10 +7,12 @@ The script installs Guacamole, guacd, and postgres.
 - Access to running kubectl commands
 
 ## Install
-- Move the `init-guac.sh` script to a server with access to running kubectl commands.
+- Move `init-guac.sh`, `guacamole.yaml`, `postgres.yaml`, and `initdb.sql` to a server with access to running kubectl commands. 
 - Run `chmod +x init-guac.sh` to make it executable.
 - Run `./init-guac.sh`.
     - You will be asked to create a password for the postgres database and a username + password for the admin Guacamole user.
+
+**Note:** The `initdb.sql` (postgres init script) has been created with Docker. See instructions [here](https://guacamole.apache.org/doc/0.9.7/gug/guacamole-docker.html).
 
 ## Check Setup
 - Run `kubectl get pods -n guacamole` to check the status of the components. 

--- a/install-guacamole/README.md
+++ b/install-guacamole/README.md
@@ -18,7 +18,8 @@ The script installs Guacamole, guacd, and postgres.
 ## Connecting to Guacamole
 - The script outputs the address for connecting to guacamole. 
 - It can also be found by running `kubectl get svc -n guacamole` and using the form `http://<public-server-ip>:guacamole-exposed-nodeport/guacamole`.
-- The default username and password is `guacadmin`.
+
+**Note:** The Guacamole admin password will not be updated until `src/main.go` is run. Before this the default username and password `guacadmin` can be used to log in if necessary.
 
 ## Manually Connecting to Kali via Guacamole Interface
 - Make sure that there is a Kali container running. 

--- a/install-guacamole/init-guac.sh
+++ b/install-guacamole/init-guac.sh
@@ -65,7 +65,7 @@ while true; do
         break
     else
         echo "Pod $POD is not ready yet. Retrying in 5 seconds..."
-        sleep 5
+        sleep 3
     fi
 done
 
@@ -83,8 +83,11 @@ while true; do
   sleep 3
 done
 
+# To avoid connection errors when running the database init script
+sleep 10
+
 echo "##### Run DB init script"
-POSTGRES_CONNECTION_STRING="postgresql://guacamole:${DB_PASSWORD}@localhost:${POSTGRES_PORT}/guacamole"
+POSTGRES_CONNECTION_STRING="postgresql://guacamole:${DB_PASSWORD}@${POSTGRES_IP}:${POSTGRES_PORT}/guacamole"
 kubectl exec -it "$POSTGRES_POD" -n guacamole -- psql "$POSTGRES_CONNECTION_STRING" < initdb.sql
 
 echo "##### Updating guacamole secret with postgres IP"
@@ -101,5 +104,5 @@ PUBLIC_IP=$(ip -f inet -o addr show eth0|cut -d\  -f 7 | cut -d/ -f 1 | head -n 
 PORT=$(kubectl get service guacamole -n guacamole -o=jsonpath='{.spec.ports[0].nodePort}')
 
 echo "You can access guacamole on ${PUBLIC_IP}:${PORT}/guacamole"
-echo "The default username is: guacadmin"
-echo "Use the password you chose"
+echo "The default username and password is: guacadmin"
+echo "Run src/main.go to update the password to the chosen one"

--- a/src/README.md
+++ b/src/README.md
@@ -3,6 +3,8 @@
 
 **Requirements** 
 
+- Go installed
+- Docker installed
 - Valid K8s config file available 
 - Valid Digital Ocean secret available (for getting Docker images from the cloud registry). This should be in `dockerconfig.json` format
 - Knowledge of the server's IP

--- a/src/main.go
+++ b/src/main.go
@@ -53,25 +53,23 @@ func main() {
 }
 
 func setupGuacamole(clientSet kubernetes.Clientset) (guacamole.Guacamole, error) {
-	guacUser, guacPassword, err := guacamole.GetGuacamoleSecret(clientSet)
-	if err != nil {
-		return guacamole.Guacamole{}, err
-	}
-
 	guacBaseAddress, err := guacamole.GetGuacamoleBaseAddress(clientSet)
 	if err != nil {
 		return guacamole.Guacamole{}, err
 	}
 
+	// Default guacamole credentials used to initially change the admin password
 	guac := guacamole.Guacamole{
-		Username: guacUser,
-		Password: guacPassword,
+		Username: "guacadmin",
+		Password: "guacadmin",
 		BaseUrl:  guacBaseAddress,
 	}
-	err = guac.UpdateAdminPasswordInGuac("guacadmin")
+
+	err = guac.UpdateDefaultGuacAdminPassword(clientSet, "guacadmin")
 	if err != nil {
 		return guacamole.Guacamole{}, err
 	}
+
 	return guac, nil
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	port := ":" + utils.APIPort
 
-	kubeConfigPath := os.Getenv("KUBECONFIG") //running without docker requires 'export KUBECONFIG="$HOME/.kube/config"'
+	kubeConfigPath := os.Getenv("KUBECONFIG")
 	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 	utils.ErrLogger(err)
 	clientSet, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
Fixes problems with the Guacamole setup where the admin default password could not be updated. 
Also adds info about Docker + go requirements for the main program.

- [x] Fix admin password setting
- [x] Fix connection errors when trying to run initdb.sql script
- [x] Update readme Guac
- [x] Update main readme
- [x] Test the guac parts on a clean droplet 